### PR TITLE
Revert "[protobuf-cpp] update to 3.13.0"

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,13 +1,13 @@
 pkg_name=protobuf-cpp
 pkg_distname=protobuf
 pkg_origin=core
-pkg_version=3.13.0
+pkg_version=3.9.2
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data."
 pkg_upstream_url="https://github.com/google/${pkg_distname}"
 pkg_source="https://github.com/google/${pkg_distname}/releases/download/v${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=f8a547dfe143a9f61fadafba47fa6573713a33cb80909307c1502e26e1102298
+pkg_shasum=1891110cce323fe56b509da3589f03756c7eaf462a60971cb1c4af4efb154f69
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_deps=(core/gcc core/zlib)
 pkg_build_deps=(core/make)


### PR DESCRIPTION
This reverts commit 9aa804a02e5cf07b963e6db6343fc3e61fb2a8d2.
